### PR TITLE
Use parens on a print() in the test script

### DIFF
--- a/Ska/quatutil.py
+++ b/Ska/quatutil.py
@@ -2,7 +2,7 @@ import numpy as np
 from numpy import sin, cos, tan, arctan2, radians, degrees, sqrt
 from Quaternion import Quat
 
-__version__ = '3.3.1'
+__version__ = '3.3.2'
 
 
 def radec2eci(ra, dec):

--- a/test_quatutils.py
+++ b/test_quatutils.py
@@ -76,7 +76,7 @@ def test_quat_x_to_vec():
         for method in ('keep_z', 'shortest', 'radec'):
             q = Ska.quatutil.quat_x_to_vec(vec, method)
             vec1 = np.dot(q.transform, [1.0, 0, 0])
-            print method, vec, vec1
+            print(method, vec, vec1)
             for i in range(3):
                 assert_almost_equal(vec[i], vec1[i])
             if method == 'radec':


### PR DESCRIPTION
Use parens on a print() in the test script .  Fixes failure to run test script on PY3.