### PR TITLE
Version for shiny

### DIFF
--- a/Ska/quatutil/__init__.py
+++ b/Ska/quatutil/__init__.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-__version__ = '3.3.2'
+import ska_helpers
+__version__ = ska_helpers.get_version('Ska.quatutil')
 
 from .quatutil import *  # noqa
 

--- a/Ska/quatutil/quatutil.py
+++ b/Ska/quatutil/quatutil.py
@@ -3,10 +3,6 @@ import numpy as np
 from numpy import sin, cos, tan, arctan2, radians, degrees, sqrt
 from Quaternion import Quat
 
-import ska_helpers
-
-__version__ = ska_helpers.get_version(__package__)
-
 
 def radec2eci(ra, dec):
     """


### PR DESCRIPTION
## Description

Make pytest no longer fail because of issues with ska_helpers and version.

## Testing

- [x] Passes unit tests on MacOS ska3-shiny
- [x] Passes unit tests on MacOS ska3 (flight)
